### PR TITLE
Feat: 카테고리 목록 조회 api, 카테고리에 따른 질문글 조회 api 구현

### DIFF
--- a/src/main/java/com/the_dapda/domain/category/controller/CategoryQueryController.java
+++ b/src/main/java/com/the_dapda/domain/category/controller/CategoryQueryController.java
@@ -1,0 +1,30 @@
+package com.the_dapda.domain.category.controller;
+
+import com.the_dapda.domain.category.dto.response.CategoryResponse;
+import com.the_dapda.domain.category.service.CategoryQueryService;
+import com.the_dapda.global.response.ResponseCode;
+import com.the_dapda.global.response.ResponseForm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/categories")
+public class CategoryQueryController {
+
+    private final CategoryQueryService categoryQueryService;
+
+    @GetMapping
+    public ResponseEntity<ResponseForm> getCategories() {
+        List<CategoryResponse> categoryResponses = categoryQueryService.getCategories();
+
+        return categoryResponses != null ?
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.EXAMPLE_SUCCESS, categoryResponses)) :
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.EXAMPLE_FAIL ));
+    }
+}

--- a/src/main/java/com/the_dapda/domain/category/dto/response/CategoryResponse.java
+++ b/src/main/java/com/the_dapda/domain/category/dto/response/CategoryResponse.java
@@ -1,0 +1,22 @@
+package com.the_dapda.domain.category.dto.response;
+
+import com.the_dapda.domain.category.entity.Category;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoryResponse {
+
+    private Long categoryId;
+    private String title;
+
+    public CategoryResponse(Category category) {
+        this.categoryId = category.getId();
+        this.title = category.getTitle();
+    }
+}

--- a/src/main/java/com/the_dapda/domain/category/service/CategoryQueryService.java
+++ b/src/main/java/com/the_dapda/domain/category/service/CategoryQueryService.java
@@ -1,0 +1,10 @@
+package com.the_dapda.domain.category.service;
+
+import com.the_dapda.domain.category.dto.response.CategoryResponse;
+
+import java.util.List;
+
+public interface CategoryQueryService {
+
+    List<CategoryResponse> getCategories();
+}

--- a/src/main/java/com/the_dapda/domain/category/service/impl/CategoryQueryServiceImpl.java
+++ b/src/main/java/com/the_dapda/domain/category/service/impl/CategoryQueryServiceImpl.java
@@ -1,0 +1,26 @@
+package com.the_dapda.domain.category.service.impl;
+
+import com.the_dapda.domain.category.dto.response.CategoryResponse;
+import com.the_dapda.domain.category.repository.CategoryRepository;
+import com.the_dapda.domain.category.service.CategoryQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CategoryQueryServiceImpl implements CategoryQueryService {
+
+    private final CategoryRepository categoryRepository;
+
+    @Override
+    public List<CategoryResponse> getCategories() {
+        return categoryRepository.findAll()
+                .stream()
+                .map(CategoryResponse::new)
+                .toList();
+    }
+}

--- a/src/main/java/com/the_dapda/domain/diary/controller/DiaryCommandController.java
+++ b/src/main/java/com/the_dapda/domain/diary/controller/DiaryCommandController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
 @RequiredArgsConstructor
-@RequestMapping("/diarys")
+@RequestMapping("/diaries")
 public class DiaryCommandController {
 
     private final DiaryCommandService diaryCommandService;

--- a/src/main/java/com/the_dapda/domain/diary/controller/DiaryQueryController.java
+++ b/src/main/java/com/the_dapda/domain/diary/controller/DiaryQueryController.java
@@ -1,0 +1,29 @@
+package com.the_dapda.domain.diary.controller;
+
+import com.the_dapda.domain.diary.dto.response.QuestionResponse;
+import com.the_dapda.domain.diary.service.query.DiaryQueryService;
+import com.the_dapda.global.response.ResponseCode;
+import com.the_dapda.global.response.ResponseForm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/diaries")
+public class DiaryQueryController {
+
+    private final DiaryQueryService diaryQueryService;
+
+    @GetMapping("/{categoryId}")
+    public ResponseEntity<ResponseForm> getQuestion(@PathVariable("categoryId") Long categoryId) {
+        QuestionResponse questionResponse = diaryQueryService.getQuestion(categoryId);
+
+        return questionResponse != null ?
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.EXAMPLE_SUCCESS, questionResponse)) :
+                ResponseEntity.ok(ResponseForm.of(ResponseCode.EXAMPLE_FAIL ));
+    }
+}

--- a/src/main/java/com/the_dapda/domain/diary/dto/response/QuestionResponse.java
+++ b/src/main/java/com/the_dapda/domain/diary/dto/response/QuestionResponse.java
@@ -1,0 +1,15 @@
+package com.the_dapda.domain.diary.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuestionResponse {
+
+    private String question;
+}

--- a/src/main/java/com/the_dapda/domain/diary/service/query/DiaryQueryService.java
+++ b/src/main/java/com/the_dapda/domain/diary/service/query/DiaryQueryService.java
@@ -1,0 +1,8 @@
+package com.the_dapda.domain.diary.service.query;
+
+import com.the_dapda.domain.diary.dto.response.QuestionResponse;
+
+public interface DiaryQueryService {
+
+    QuestionResponse getQuestion(Long categoryId);
+}

--- a/src/main/java/com/the_dapda/domain/diary/service/query/impl/DiaryQueryServiceImpl.java
+++ b/src/main/java/com/the_dapda/domain/diary/service/query/impl/DiaryQueryServiceImpl.java
@@ -1,0 +1,26 @@
+package com.the_dapda.domain.diary.service.query.impl;
+
+import com.the_dapda.domain.category.entity.Category;
+import com.the_dapda.domain.category.repository.CategoryRepository;
+import com.the_dapda.domain.diary.dto.response.QuestionResponse;
+import com.the_dapda.domain.diary.service.query.DiaryQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DiaryQueryServiceImpl implements DiaryQueryService {
+
+    private final CategoryRepository categoryRepository;
+
+    public QuestionResponse getQuestion(Long categoryId) {
+        Category category = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new RuntimeException("no category"));
+
+        // 카테고리를 통해 질문글 조회 로직 필요
+
+        return new QuestionResponse();
+    }
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### 반영 브랜치
Feat/diary -> main

### 오늘 한 일
카테고리 목록 조회 api를 구현했습니다.
카테고리에 따른 질문글 조회 api를 구현했습니다.

### 논의할 내용
1. 스프링 시큐리티에서 api 경로를 허용 해야 포스트맨으로 테스트를 진행 할 수 있을거 같습니다.
2. 아래 로직은 카테고리에 따른 질문글 조회 api 입니다.
주석에 작성한 것처럼 카테고리를 통해 질문글 조회 로직 필요합니다.
```java
@Service
@RequiredArgsConstructor
@Transactional(readOnly = true)
public class DiaryQueryServiceImpl implements DiaryQueryService {

    private final CategoryRepository categoryRepository;

    public QuestionResponse getQuestion(Long categoryId) {
        Category category = categoryRepository.findById(categoryId)
                .orElseThrow(() -> new RuntimeException("no category"));

        // 카테고리를 통해 질문글 조회 로직 필요

        return new QuestionResponse();
    }
}
```

### 내일 할 일
질문 일기 내용 삭제
질문 일기 세부 내용 조회
질문 일기 목록 조회

### 참고 자료
